### PR TITLE
Use find_package for zlib for avoiding unittests

### DIFF
--- a/cmake/gRPC.cmake
+++ b/cmake/gRPC.cmake
@@ -75,12 +75,12 @@ if(GWHISPER_FORCE_BUILDING_GRPC OR GRPC_NOT_FOUND)
     # Adding the "EXCLUDE_FROM_ALL" here, to prevent install targets to be added
     # As we do not want to intsall whole gRPC and its depdendencies to the system.
     # We do not want to build any tests from grpc
-    SET(BUILD_TESTING OFF)
+    set(BUILD_TESTING OFF)
     # The zlib module is not intended to be included as sub directory
     # Building tests without the neded dependencies, making
     # a regression run fail
     # zlib can be expected to be systemwide available
-    SET(gRPC_ZLIB_PROVIDER package)
+    set(gRPC_ZLIB_PROVIDER "package" CACHE STRING "force overwritten by gWhisper" FORCE )
     add_subdirectory(${grpc_SOURCE_DIR} ${grpc_BINARY_DIR} EXCLUDE_FROM_ALL)
 
     # Since FetchContent uses add_subdirectory under the hood, we can use

--- a/cmake/gRPC.cmake
+++ b/cmake/gRPC.cmake
@@ -74,8 +74,13 @@ if(GWHISPER_FORCE_BUILDING_GRPC OR GRPC_NOT_FOUND)
     endif()
     # Adding the "EXCLUDE_FROM_ALL" here, to prevent install targets to be added
     # As we do not want to intsall whole gRPC and its depdendencies to the system.
-    # NOTE: This unfortunately does not work for tests, which causes us to do some
-    #       Hacks because of zlib tests being not disableable
+    # We do not want to build any tests from grpc
+    SET(BUILD_TESTING OFF)
+    # The zlib module is not intended to be included as sub directory
+    # Building tests without the neded dependencies, making
+    # a regression run fail
+    # zlib can be expected to be systemwide available
+    SET(gRPC_ZLIB_PROVIDER package)
     add_subdirectory(${grpc_SOURCE_DIR} ${grpc_BINARY_DIR} EXCLUDE_FROM_ALL)
 
     # Since FetchContent uses add_subdirectory under the hood, we can use

--- a/tests/unitTests/CMakeLists.txt
+++ b/tests/unitTests/CMakeLists.txt
@@ -40,18 +40,4 @@ if(BUILD_CONFIG_USE_BOOST_REGEX)
     )
 endif()
 
-# This is an ugly workaround to build zlib examples, as I cannot manage to disable
-# zlib tests. They always run as part of gwhisper tests.
-# However, as I need to EXCLUDE_FROM_ALL for gRPC dependency to avoid installing
-# all gRPC stuff, I am not building the examples, which causes zlib test to fail.
-# by adding a dependency here, I enforce building of the zlib tests.
-# This is a limitation of FetchContent. If anyone knows how to solve this (do
-# not install anythinf and do not test anything from FetchContent depdendencies) please tell me.
-if (TARGET example)
-    add_dependencies(${TARGET_NAME} example)
-endif()
-if (TARGET example64)
-    add_dependencies(${TARGET_NAME} example64)
-endif()
-
 add_test(NAME UnitTests COMMAND ${TARGET_NAME})


### PR DESCRIPTION
The zlib module build of grpc unfortunately enables
testing and tries to build the example tests.

With this patch zlib from the system environment will be used.

Signed-off-by: Fabian Pfeifroth-Brumm <fabian@pfeifroth.de>