### PR TITLE
fix missing include for darwin/arm64

### DIFF
--- a/src/libCli/MessageParserCli.cpp
+++ b/src/libCli/MessageParserCli.cpp
@@ -15,6 +15,7 @@
 #include <libCli/MessageParser.hpp>
 #include <fstream>
 #include <exception>
+#include <sstream>
 
 using namespace ArgParse;
 


### PR DESCRIPTION
https://github.com/IBM/gWhisper/issues/116

I fixed this in #115 but seems to have been accidentally removed