### PR TITLE
fixGwhisperHangOnDescDbStreamClose

### DIFF
--- a/src/libCli/ConnectionManager.cpp
+++ b/src/libCli/ConnectionManager.cpp
@@ -75,7 +75,7 @@ namespace cli
         }
         
         //if proxy exists close the stream with a deadline.
-        grpc::Status status = m_connections[f_serverAddress].descDbProxy->closeDbStream(deadline);
+        grpc::Status status = m_connections[f_serverAddress].descDbProxy->closeDescDbStream(deadline);
         
         //delete the proxy, findChannelByAddress() protects from accessing uninitialzed DbProxy.
         m_connections[f_serverAddress].descDbProxy.reset();

--- a/src/libCli/ConnectionManager.cpp
+++ b/src/libCli/ConnectionManager.cpp
@@ -65,6 +65,24 @@ namespace cli
         return m_connections[f_serverAddress].descPool;
     }
 
+    grpc::Status ConnectionManager::closeDescDbWithDeadline(std::string f_serverAddress,
+                                                    std::optional<std::chrono::time_point<std::chrono::system_clock>> deadline)
+    {
+        if (m_connections[f_serverAddress].descDbProxy == nullptr)
+        {
+            std::cerr << "Error: Unable to close DescDb connection!" << std::endl;
+            return grpc::Status( grpc::StatusCode::ABORTED, "descDbProxy has not been initialized.");
+        }
+        
+        //if proxy exists close the stream with a deadline.
+        grpc::Status status = m_connections[f_serverAddress].descDbProxy->closeDbStream(deadline);
+        
+        //delete the proxy, findChannelByAddress() protects from accessing uninitialzed DbProxy.
+        m_connections[f_serverAddress].descDbProxy.reset();
+
+        return status;
+    }
+
     void ConnectionManager::ensureDescDbProxyAndDescPoolIsAvailable(std::string &f_serverAddress, ArgParse::ParsedElement &f_parseTree)
     {
         if (m_connections[f_serverAddress].channel)

--- a/src/libCli/libCli/ConnectionManager.hpp
+++ b/src/libCli/libCli/ConnectionManager.hpp
@@ -52,6 +52,11 @@ namespace cli
         /// @returns the gRpc DescriptorPool of the corresponding server address.
         std::shared_ptr<grpc::protobuf::DescriptorPool> getDescPool(std::string f_serverAddress, ArgParse::ParsedElement &f_parseTree);
 
+        /// @brief closes the DescDb stream with a given deadline.
+        /// @param f_serverAddress server addresss to lookup the assigned DescDbProxy.
+        /// @param deadline optional dealine for closing the stream.
+        /// @return returns grpc::StatusCode::ABORTED status if no DescDb proxy is attached to the server address, 
+        /// otherwise grpc status as a result of stream closure.
         grpc::Status closeDescDbWithDeadline(std::string f_serverAddress,
                                             std::optional<std::chrono::time_point<std::chrono::system_clock>> deadline);
 

--- a/src/libCli/libCli/ConnectionManager.hpp
+++ b/src/libCli/libCli/ConnectionManager.hpp
@@ -52,6 +52,9 @@ namespace cli
         /// @returns the gRpc DescriptorPool of the corresponding server address.
         std::shared_ptr<grpc::protobuf::DescriptorPool> getDescPool(std::string f_serverAddress, ArgParse::ParsedElement &f_parseTree);
 
+        grpc::Status closeDescDbWithDeadline(std::string f_serverAddress,
+                                            std::optional<std::chrono::time_point<std::chrono::system_clock>> deadline);
+
     private:
         ConnectionManager() {}
         ~ConnectionManager() {}

--- a/src/libLocalDescriptorCache/DescDbProxy.cpp
+++ b/src/libLocalDescriptorCache/DescDbProxy.cpp
@@ -350,12 +350,27 @@ void DescDbProxy::getDescriptors(const std::string &f_hostAddress)
     }
 }
 
+grpc::Status DescDbProxy::closeDbStream(std::optional<std::chrono::time_point<std::chrono::system_clock>> deadline)
+{
+    if( m_disableCache  == false )//cache enabled, no reflection stream required.
+    {
+        return grpc::Status::OK;
+    }
+
+    if ( m_reflectionDescDb == nullptr )
+    {
+        std::cerr << "Exit - no reflectionDescDb initialized." <<std::endl;
+        exit(EXIT_FAILURE);
+    }
+    return m_reflectionDescDb->closeStreamWithDeadline(deadline);
+}
+
 DescDbProxy::DescDbProxy(bool disableCache, const std::string &hostAddress, std::shared_ptr<grpc::Channel> channel, 
                                                                             ArgParse::ParsedElement &parseTree)
 {
     m_channel = channel;
     m_parseTree = parseTree;
-
+    m_disableCache = disableCache;
     if(disableCache)
     {
         // Get Desc directly via reflection and without touching localDB

--- a/src/libLocalDescriptorCache/DescDbProxy.cpp
+++ b/src/libLocalDescriptorCache/DescDbProxy.cpp
@@ -354,12 +354,7 @@ grpc::Status DescDbProxy::closeDescDbStream(std::optional<std::chrono::time_poin
 {
     if ( m_reflectionDescDb == nullptr )
     {
-        if( m_disableCache  == false )//cache enabled, no reflection stream required.
-        {
-            return grpc::Status::OK;
-        }
-        std::cerr << "Exit - no reflectionDescDb initialized." <<std::endl;
-        exit(EXIT_FAILURE);
+        return grpc::Status::OK;
     }
     return m_reflectionDescDb->closeStreamWithDeadline(deadline);
 }

--- a/src/libLocalDescriptorCache/DescDbProxy.cpp
+++ b/src/libLocalDescriptorCache/DescDbProxy.cpp
@@ -352,13 +352,12 @@ void DescDbProxy::getDescriptors(const std::string &f_hostAddress)
 
 grpc::Status DescDbProxy::closeDescDbStream(std::optional<std::chrono::time_point<std::chrono::system_clock>> deadline)
 {
-    if( m_disableCache  == false )//cache enabled, no reflection stream required.
-    {
-        return grpc::Status::OK;
-    }
-
     if ( m_reflectionDescDb == nullptr )
     {
+        if( m_disableCache  == false )//cache enabled, no reflection stream required.
+        {
+            return grpc::Status::OK;
+        }
         std::cerr << "Exit - no reflectionDescDb initialized." <<std::endl;
         exit(EXIT_FAILURE);
     }

--- a/src/libLocalDescriptorCache/DescDbProxy.cpp
+++ b/src/libLocalDescriptorCache/DescDbProxy.cpp
@@ -350,7 +350,7 @@ void DescDbProxy::getDescriptors(const std::string &f_hostAddress)
     }
 }
 
-grpc::Status DescDbProxy::closeDbStream(std::optional<std::chrono::time_point<std::chrono::system_clock>> deadline)
+grpc::Status DescDbProxy::closeDescDbStream(std::optional<std::chrono::time_point<std::chrono::system_clock>> deadline)
 {
     if( m_disableCache  == false )//cache enabled, no reflection stream required.
     {

--- a/src/libLocalDescriptorCache/DescDbProxy.hpp
+++ b/src/libLocalDescriptorCache/DescDbProxy.hpp
@@ -58,7 +58,10 @@ class DescDbProxy : public grpc::protobuf::DescriptorDatabase{
     /// @param hostAdress Address to the current host 
     void getDescriptors(const std::string &hostAddress);
 
-    grpc::Status closeDbStream(std::optional<std::chrono::time_point<std::chrono::system_clock>> deadline);
+    /// @brief close the DescDb stream with a given deadline. If the dealine is not set it waits for the stream to close indefinitely.
+    /// @param deadline optional deadline to close the DescDb stream.
+    /// @return return grpc status as a result of call the finish() on the DescDb stream.
+    grpc::Status closeDescDbStream(std::optional<std::chrono::time_point<std::chrono::system_clock>> deadline);
    
     DescDbProxy(bool disableCache, const std::string &hostAddress, std::shared_ptr<grpc::Channel> channel, ArgParse::ParsedElement &parseTree);
 

--- a/src/libLocalDescriptorCache/DescDbProxy.hpp
+++ b/src/libLocalDescriptorCache/DescDbProxy.hpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <time.h>
 #include <set>
+#include <optional>
 
 #include <grpcpp/grpcpp.h>
 #include <gRPC_utils/proto_reflection_descriptor_database.h>
@@ -56,6 +57,8 @@ class DescDbProxy : public grpc::protobuf::DescriptorDatabase{
     /// Stores DescDB acquired via sever reflection locally as a DB file in proto3 structure.
     /// @param hostAdress Address to the current host 
     void getDescriptors(const std::string &hostAddress);
+
+    grpc::Status closeDbStream(std::optional<std::chrono::time_point<std::chrono::system_clock>> deadline);
    
     DescDbProxy(bool disableCache, const std::string &hostAddress, std::shared_ptr<grpc::Channel> channel, ArgParse::ParsedElement &parseTree);
 
@@ -112,5 +115,6 @@ class DescDbProxy : public grpc::protobuf::DescriptorDatabase{
     std::vector<const grpc::protobuf::FileDescriptor*>m_descList;
     std::set<std::string> m_descNames;
     std::vector<grpc::string> m_serviceList;
+    bool m_disableCache;
 };
 

--- a/third_party/gRPC_utils/gRPC_utils/proto_reflection_descriptor_database.h
+++ b/third_party/gRPC_utils/gRPC_utils/proto_reflection_descriptor_database.h
@@ -80,6 +80,8 @@ class ProtoReflectionDescriptorDatabase : public protobuf::DescriptorDatabase {
   // Provide a list of full names of registered services
   bool GetServices(std::vector<grpc::string>* output);
 
+  grpc::Status closeStreamWithDeadline(std::optional<std::chrono::time_point<std::chrono::system_clock>> deadline);
+
  private:
   typedef ClientReaderWriter<
       grpc::reflection::v1alpha::ServerReflectionRequest,
@@ -97,6 +99,8 @@ class ProtoReflectionDescriptorDatabase : public protobuf::DescriptorDatabase {
   bool DoOneRequest(
       const grpc::reflection::v1alpha::ServerReflectionRequest& request,
       grpc::reflection::v1alpha::ServerReflectionResponse& response);
+
+  grpc::Status closeStream();
 
   std::shared_ptr<ClientStream> stream_;
   grpc::ClientContext ctx_;

--- a/third_party/gRPC_utils/gRPC_utils/proto_reflection_descriptor_database.h
+++ b/third_party/gRPC_utils/gRPC_utils/proto_reflection_descriptor_database.h
@@ -80,6 +80,9 @@ class ProtoReflectionDescriptorDatabase : public protobuf::DescriptorDatabase {
   // Provide a list of full names of registered services
   bool GetServices(std::vector<grpc::string>* output);
 
+  /// @brief close the reflection stream with a given deadline. If the dealine is not set it waits for the stream to close indefinitely.
+  /// @param deadline optional deadline to close the reflection stream.
+  /// @return return grpc status as a result of call the finish() on the reflection stream.
   grpc::Status closeStreamWithDeadline(std::optional<std::chrono::time_point<std::chrono::system_clock>> deadline);
 
  private:

--- a/third_party/gRPC_utils/gRPC_utils/proto_reflection_descriptor_database.h
+++ b/third_party/gRPC_utils/gRPC_utils/proto_reflection_descriptor_database.h
@@ -28,6 +28,8 @@
 // MODIFIED by IBM (Rainer Schoenberger)
 // original: #include "src/proto/grpc/reflection/v1alpha/reflection.grpc.pb.h"
 // MODIFIED by IBM (Fabian Pfeifroth-Brumm)
+// MODIFIED by IBM (Rahman Abber Tahir)
+#include <optional>
 #include "reflection.grpc.pb.h"
 // END MODIFIED
 


### PR DESCRIPTION
close reflection stream with a deadline after fetching services description data.

- Dynamic deadlines are now propagated to the DescDb stream close.

- The db stream is now closed after 2 (after fetching name and type info from server).