### PR TITLE
Update grpc to 1.62.0

### DIFF
--- a/cmake/gRPC.cmake
+++ b/cmake/gRPC.cmake
@@ -60,10 +60,11 @@ if(GWHISPER_FORCE_BUILDING_GRPC OR GRPC_NOT_FOUND)
     unset(PROTC_GRPC_PLUGIN CACHE)
 
     include(FetchContent)
+    set(ABSL_ENABLE_INSTALL ON)
     FetchContent_Declare(
         grpc
         GIT_REPOSITORY https://github.com/grpc/grpc
-        GIT_TAG        v1.43.0
+        GIT_TAG        v1.62.0
         GIT_PROGRESS TRUE
     )
     set(FETCHCONTENT_QUIET OFF)
@@ -87,7 +88,7 @@ if(GWHISPER_FORCE_BUILDING_GRPC OR GRPC_NOT_FOUND)
     if(CMAKE_SYSTEM_PROCESSOR STREQUAL "s390x")
         set(gRPC_SSL_PROVIDER "package" CACHE STRING "force overwritten by gWhisper, as boringSSL does not support s390x -> need to fall-back to system installed libssl" FORCE )
     endif()
-
+    set(ABSL_PROPAGATE_CXX_STD ON CACHE STRING "force overwritten by gWhisper to conform to Abseil recommendations" FORCE )
     add_subdirectory(${grpc_SOURCE_DIR} ${grpc_BINARY_DIR} EXCLUDE_FROM_ALL)
 
     # Since FetchContent uses add_subdirectory under the hood, we can use

--- a/cmake/gRPC.cmake
+++ b/cmake/gRPC.cmake
@@ -60,7 +60,10 @@ if(GWHISPER_FORCE_BUILDING_GRPC OR GRPC_NOT_FOUND)
     unset(PROTC_GRPC_PLUGIN CACHE)
 
     include(FetchContent)
+
+    # Workaround for https://github.com/protocolbuffers/protobuf/issues/12185 :
     set(ABSL_ENABLE_INSTALL ON)
+
     FetchContent_Declare(
         grpc
         GIT_REPOSITORY https://github.com/grpc/grpc

--- a/src/libCli/MessageFormatterJson.cpp
+++ b/src/libCli/MessageFormatterJson.cpp
@@ -27,8 +27,8 @@ namespace cli
 
         // Will print primitive fields regardless of their values. So e.g. an int32 field set to 0 will not be omitted. 
         printOptions.always_print_primitive_fields = true;
-        
-        google::protobuf::util::Status status = google::protobuf::util::MessageToJsonString(f_message, &resultString, printOptions);
+
+        auto status = google::protobuf::util::MessageToJsonString(f_message, &resultString, printOptions);
         if(not status.ok())
         {
             resultString = std::string("Json encoding of Message failed: ") + status.ToString();

--- a/src/libCli/MessageFormatterJson.cpp
+++ b/src/libCli/MessageFormatterJson.cpp
@@ -28,7 +28,7 @@ namespace cli
         // Will print primitive fields regardless of their values. So e.g. an int32 field set to 0 will not be omitted. 
         printOptions.always_print_primitive_fields = true;
 
-        auto status = google::protobuf::util::MessageToJsonString(f_message, &resultString, printOptions);
+        const auto status = google::protobuf::util::MessageToJsonString(f_message, &resultString, printOptions);
         if(not status.ok())
         {
             resultString = std::string("Json encoding of Message failed: ") + status.ToString();

--- a/src/libCli/MessageParserJson.cpp
+++ b/src/libCli/MessageParserJson.cpp
@@ -54,9 +54,8 @@ std::vector<std::unique_ptr<google::protobuf::Message>> MessageParserJson::parse
             }
             std::stringstream buffer;
             buffer << source->rdbuf();
-            std::string fileContent = buffer.str();
             auto status = google::protobuf::util::JsonStringToMessage(
-                    fileContent,
+                    buffer.str(),
                     message.get(),
                     google::protobuf::util::JsonParseOptions());
             if(not status.ok())

--- a/src/libCli/MessageParserJson.cpp
+++ b/src/libCli/MessageParserJson.cpp
@@ -56,7 +56,7 @@ std::vector<std::unique_ptr<google::protobuf::Message>> MessageParserJson::parse
             buffer << source->rdbuf();
             std::string fileContent = buffer.str();
             auto status = google::protobuf::util::JsonStringToMessage(
-                    google::protobuf::StringPiece(fileContent),
+                    fileContent,
                     message.get(),
                     google::protobuf::util::JsonParseOptions());
             if(not status.ok())

--- a/tests/functionTests/completionTests.txt
+++ b/tests/functionTests/completionTests.txt
@@ -63,6 +63,7 @@ Possible Candidates:
 127.0.0.1 examples.StreamingRpcs        (uni- and bi-directional streams)
 127.0.0.1 examples.StatusHandling                   (gRPC error handling)
 /^127.0.0.1 grpc.reflection.*$
+/^127.0.0.1 grpc.reflection.*$
 #END_TEST
 
 #START_TEST complete rpcTimeout 

--- a/tests/functionTests/completionTests_fish.txt
+++ b/tests/functionTests/completionTests_fish.txt
@@ -64,6 +64,7 @@ Possible Candidates:
 127.0.0.1 examples.StreamingRpcs        (uni- and bi-directional streams)
 127.0.0.1 examples.StatusHandling                   (gRPC error handling)
 /^127.0.0.1 grpc.reflection.*$
+/^127.0.0.1 grpc.reflection.*$
 #END_TEST
 
 #START_TEST complete rpcTimeout 

--- a/tests/functionTests/rpcExecutionTests.txt
+++ b/tests/functionTests/rpcExecutionTests.txt
@@ -200,9 +200,7 @@ RPC succeeded :D
 
 #START_TEST json_input_stdin_malformed
 cat @@testResources@@/duplicateEverything1d_malformed.json | @@CMD@@ --disableCache --jsonInput=- 127.0.0.1 examples.NestedTypeRpcs duplicateEverything1d
-Warning: Failed to parse JSON file '-': INVALID_ARGUMENT:Unexpected end of string. Expected , or } after key:value pair.
-
-^
+/Warning: Failed to parse JSON file '-': .*
 Error parsing method arguments -> aborting the call :-(
 #END_TEST
 

--- a/third_party/gRPC_utils/gRPC_utils/cli_call.h
+++ b/third_party/gRPC_utils/gRPC_utils/cli_call.h
@@ -1,20 +1,20 @@
-/*
- *
- * Copyright 2015 gRPC authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
+//
+//
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
 
 #ifndef GRPC_TEST_CPP_UTIL_CLI_CALL_H
 #define GRPC_TEST_CPP_UTIL_CLI_CALL_H
@@ -47,40 +47,37 @@ namespace testing {
 // and thread-unsafe methods should not be used together.
 class CliCall final {
  public:
-  typedef std::multimap<grpc::string, grpc::string> OutgoingMetadataContainer;
+  typedef std::multimap<std::string, std::string> OutgoingMetadataContainer;
   typedef std::multimap<grpc::string_ref, grpc::string_ref>
       IncomingMetadataContainer;
 
   // MODIFIED by IBM (Anna Riesch)
   // original: no argument "deadline"
   CliCall(const std::shared_ptr<grpc::Channel>& channel,
-          const grpc::string& method,
+          const std::string& method,
           const OutgoingMetadataContainer& metadata,
           std::optional<std::chrono::time_point<std::chrono::system_clock>> deadline);
 // END MODIFIED
   ~CliCall();
 
   // Perform an unary generic RPC.
-  static Status Call(std::shared_ptr<grpc::Channel> channel,
-                     const grpc::string& method, const grpc::string& request,
-                     grpc::string* response,
-                     const OutgoingMetadataContainer& metadata,
-                     IncomingMetadataContainer* server_initial_metadata,
-                     IncomingMetadataContainer* server_trailing_metadata);
+  Status Call(const std::string& request, std::string* response,
+              IncomingMetadataContainer* server_initial_metadata,
+              IncomingMetadataContainer* server_trailing_metadata);
 
   // Send a generic request message in a synchronous manner. NOT thread-safe.
-  void Write(const grpc::string& request);
+  void Write(const std::string& request);
 
   // Send a generic request message in a synchronous manner. NOT thread-safe.
   void WritesDone();
 
   // Receive a generic response message in a synchronous manner.NOT thread-safe.
-  bool Read(grpc::string* response,
+  bool Read(std::string* response,
             IncomingMetadataContainer* server_initial_metadata);
 
   // Thread-safe write. Must be used with ReadAndMaybeNotifyWrite. Send out a
   // generic request message and wait for ReadAndMaybeNotifyWrite to finish it.
-  void WriteAndWait(const grpc::string& request);
+  void WriteAndWait(const std::string& request);
 
   // Thread-safe WritesDone. Must be used with ReadAndMaybeNotifyWrite. Send out
   // WritesDone for gereneric request messages and wait for
@@ -90,18 +87,17 @@ class CliCall final {
   // Thread-safe Read. Blockingly receive a generic response message. Notify
   // writes if they are finished when this read is waiting for a resposne.
   bool ReadAndMaybeNotifyWrite(
-      grpc::string* response,
+      std::string* response,
       IncomingMetadataContainer* server_initial_metadata);
 
   // Finish the RPC.
   Status Finish(IncomingMetadataContainer* server_trailing_metadata);
 
+  std::string peer() const { return ctx_.peer(); }
+
  private:
   std::unique_ptr<grpc::GenericStub> stub_;
-  // MODIFIED by IBM (Rainer Schoenberger)
-  // original: grpc_impl::ClientContext ctx_;
   grpc::ClientContext ctx_;
-  // END MODIFIED
   std::unique_ptr<grpc::GenericClientAsyncReaderWriter> call_;
   grpc::CompletionQueue cq_;
   gpr_mu write_mu_;


### PR DESCRIPTION
fixes #151 

The previously used gRPC version had build errors with more modern compilers.
Stepping to the most recent release.